### PR TITLE
[PATCH] Fix broken Unicode handling in pythonrc

### DIFF
--- a/.pythonrc.py
+++ b/.pythonrc.py
@@ -173,7 +173,7 @@ class EditableBufferInteractiveConsole(InteractiveConsole):
         InteractiveConsole.__init__(self, *args, **kwargs)
 
     def runsource(self, source, *args):
-        self.last_buffer = [ source.encode('latin-1') ]
+        self.last_buffer = [ source.encode('utf-8') ]
         return InteractiveConsole.runsource(self, source, *args)
 
     def raw_input(self, *args):


### PR DESCRIPTION
Hey, I have the following backtrace with your pythonrc:

<pre>
>>> s = "test with cyrillic letters: тест с кириллическими символами"
Traceback (most recent call last):
  File "/home/max/.pythonrc", line 196, in <module>
    c.interact(banner=WELCOME)
  File "/usr/lib/python2.7/code.py", line 243, in interact
    more = self.push(line)
  File "/usr/lib/python2.7/code.py", line 265, in push
    more = self.runsource(source, self.filename)
  File "/home/max/.pythonrc", line 177, in runsource
    self.last_buffer = [ source.encode('latin-1') ]
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 33-36: ordinal not in range(256)
</pre>


This is a bug, the code should not assume that the input fits in Latin1. It should use UTF-8 instead; the pull request fixes that.
