### PR TITLE
indicate if there are any untracked files

### DIFF
--- a/.zsh_shouse_prompt
+++ b/.zsh_shouse_prompt
@@ -48,7 +48,7 @@ zstyle ':vcs_info:git*:*' unstagedstr "${red}U${gray}"
 
 zstyle ':vcs_info:hg*+set-hgrev-format:*' hooks hg-hashfallback
 zstyle ':vcs_info:hg*+set-message:*' hooks mq-vcs
-zstyle ':vcs_info:git*+set-message:*' hooks git-st git-stash
+zstyle ':vcs_info:git*+set-message:*' hooks git-st git-stash git-untracked
 
 ### Dynamically set hgrevformat based on if the local rev is available
 # We don't always know the local revision, e.g. if use-simple is set
@@ -103,6 +103,19 @@ function +vi-git-stash() {
     if [[ -s ${hook_com[base]}/.git/refs/stash ]] ; then
         stashes=$(git stash list 2>/dev/null | wc -l)
         hook_com[misc]+=" (${stashes} stashed)"
+    fi
+}
+
+
+# Indicate if there are any untracked files present
+function +vi-git-untracked() {
+    local untracked
+
+    #check if there's at least 1 untracked file
+    untracked=${$(git ls-files --exclude-standard --others | head -n 1)}
+
+    if [[ -n ${untracked} ]] ; then
+        hook_com[misc]+=" ${yellow}UT${reset}"
     fi
 }
 


### PR DESCRIPTION
Hey Seth,

I loved your zsh git prompt work. However, I noticed that while you show unstaged and staged changes, you do not show untracked files (something I think vcs_info's "unstaged check" code should do, but doesn't). 

So, I wrote a function to check for just that.

Maybe you will find it useful. I didn't take too much liberty in switching the order of information around on _your_ prompt, so I just tacked it on to the misc variable. It does seems kind of out of place not being next to "S" and/or "U", so maybe you can find a place for it next to them somehow.

I won't hold it against you if you don't want to put it in. It's your prompt after all. This is me just saying thanks for the help.

Also, this is my first pull request! So let me know if anything is wrong.

Take care!

-Tim
