### PR TITLE
Minor improvement in diffconflicts script

### DIFF
--- a/bin/diffconflicts
+++ b/bin/diffconflicts
@@ -55,8 +55,14 @@ BASE=$2
 LOCAL=$3
 REMOTE=$4
 MERGED=$5
-LCONFL=$(dirname $5)/$$.left.tmp
-RCONFL=$(dirname $5)/$$.right.tmp
+
+# Extract the left (remote) and the right (local) name
+LNAME=$( awk '/^>>>>>>> / {gsub("/","."); print substr($0, 9); exit}' $MERGED )
+RNAME=$( awk '/^<<<<<<< / {gsub("/","."); print substr($0, 9); exit}' $MERGED )
+
+# Temporary files for left and right side
+LCONFL=$MERGED.REMOTE.$LNAME.$$.tmp
+RCONFL=$MERGED.LOCAL.$RNAME.$$.tmp
 
 # Remove the conflict markers for each 'side' and put each into a temp file
 sed -e '/^<<<<<<< /,/^=======$/d' -e '/^>>>>>>> /d' $MERGED > $LCONFL


### PR DESCRIPTION
Hey,

I just found your post about the diffconflicts script (http://vim.wikia.com/wiki/A_better_Vimdiff_Git_mergetool), and immediately tried it out. Works like a charm! Thanks a lot for this script!

I just made a few minor changes, the most important being the last one: I find it helpful to add the "names" of the two versions to the filenames, in order to recognise which file is shown in which window.
I extract them just from the first diff marker (in this case HEAD and origin/master):
    <<<<<<< HEAD
    foo
    =======
    bar
    >>>>>>> origin/master

If you like this change, please pull it. I would delete my fork then.

Thanks,
Clemens
