### PR TITLE
Improving diffconflicts to handle diff3 conflictstyle

### DIFF
--- a/bin/diffconflicts
+++ b/bin/diffconflicts
@@ -9,61 +9,27 @@
 # The vertical format and lack of syntax highlighting in the plain conflict
 # marker layout makes it difficult to spot subtle conflicts such as
 # single-character changes and this is where a two-way diff really shines!
-# To see this explained using screenshots, see:
-# http://vim.wikia.com/wiki/A_better_Vimdiff_Git_mergetool
 #
-# This script, when used as a Git mergetool, opens each "side" of the conflict
-# markers in a two-way vimdiff window. This combines all the awesome of Git's
-# automatic merging savvy with the awesome and simplicity of a simple two-way
-# diff.
+# This script creates 4 tab pages.  
+#  - The first tabpage contains a 2-way diff of the LOCAL and REMOTE files.
+#  - The second tabpage contains a 2-way diff of the LOCAL and BASE files.
+#  - The third tabpage coontains a 2-way diff of the REMOTE and BASE files.
+#  - The fourth tabpage contains the MERGED file showing the inline changes.
 #
-# Add this mergetool to your ~/.gitconfig (you can substitute gvim for vim):
-#
-# git config --global merge.tool diffconflicts
-# git config --global mergetool.diffconflicts.cmd 'diffconflicts vim $BASE $LOCAL $REMOTE $MERGED'
-# git config --global mergetool.diffconflicts.trustExitCode true
-# git config --global mergetool.diffconflicts.keepBackup false
-#
-# The next time you perform a merge with conflicts, invoke this tool with the
-# following command. (Of course you can set it as your default mergetool as
-# well.)
-#
-#   git mergetool --tool diffconflicts
-#
-# This tool will open three tabs in Vim that each provide a different way to
-# view the conflicts. You can resolve the conflicts in the first tab and save
-# and exit the file. This will also mark the conflict as resolved in Git.
-#
-#   Tab1 is a two-way diff of just the conflicts. Resolve the conflicts here
-#   and save the file.
-#       +--------------------------------+
-#       |    LCONFL     |    RCONFL      |
-#       +--------------------------------+
-#   Tab2 is a three-way diff of the original files and the merge base. This is
-#   the traditional three-way diff. Although noisy, it is occasionally useful
-#   to view the three original states of the conflicting file before the merge.
-#       +--------------------------------+
-#       |  LOCAL   |   BASE   |  REMOTE  |
-#       +--------------------------------+
-#   Tab3 is the in-progress merge that Git has written to the filesystem
-#   containing the conflict markers. I.e., the file you would normally edit by
-#   hand when not using a mergetool.
-#       +--------------------------------+
-#       |       <<<<<<< HEAD             |
-#       |        LCONFL                  |
-#       |       =======                  |
-#       |        RCONFL                  |
-#       |       >>>>>>> someref          |
-#       +--------------------------------+
 #
 # Workflow:
 #
-# 1.    Save your changes to the LCONFL temporary file (the left window on the
-#       first tab; also the only file that isn't read-only).
-# 2.    The LOCAL, BASE, and REMOTE versions of the file are available in the
-#       second tabpage if you want to look at them.
-# 3.    When vimdiff exits cleanly, the file containing the conflict markers
-#       will be updated with the contents of your LCONFL file edits.
+# All changes should be saved in the LOCAL file.  If vim exits without an error code, this file will be used to continue
+# the merge/rebase.
+#
+# Set the following git config settings:
+#
+#    merge.tool=diffconflicts
+#    merge.conflictstyle=diff3
+#    mergetool.prompt=false
+#    mergetool.diffconflicts.cmd=diffconflicts $EDITOR $BASE $LOCAL $REMOTE $MERGED
+#    mergetool.diffconflicts.trustexitcode=true
+#    mergetool.diffconflicts.keepbackup=false
 #
 # NOTE: Use :cq to abort the merge and exit Vim with an error code.
 
@@ -77,33 +43,25 @@ BASE="$2"
 LOCAL="$3"
 REMOTE="$4"
 MERGED="$5"
-printf -v QBASE '%q' "${BASE}"
-printf -v QLOCAL '%q' "${LOCAL}"
-printf -v QREMOTE '%q' "${REMOTE}"
-printf -v QMERGED '%q' "${MERGED}"
 
-# Temporary files for left and right side
-LCONFL="${MERGED}.REMOTE.$$.tmp"
-RCONFL="${MERGED}.LOCAL.$$.tmp"
-
-# Always delete our temp files; Git will handle it's own temp files
-trap 'rm -f "'"${LCONFL}"'" "'"${RCONFL}"'"' SIGINT SIGTERM EXIT
-
-# Remove the conflict markers for each 'side' and put each into a temp file
-sed -e '/^<<<<<<< /,/^=======$/d' -e '/^>>>>>>> /d' "${MERGED}" > "${LCONFL}"
-sed -e '/^=======$/,/^>>>>>>> /d' -e '/^<<<<<<< /d' "${MERGED}" > "${RCONFL}"
-
-# Fire up vimdiff
-$cmd -f -R -d "${LCONFL}" "${RCONFL}" \
-    -c ":set noro" \
-    -c ":tabe $QLOCAL" -c ":vert diffs $QBASE" -c ":vert diffs $QREMOTE" \
-    -c ":winc t" -c ":tabe $QMERGED" -c ":tabfir"
+# Fire up vimdiff, this could probably be improved, vim only allows 10 -c options
+$cmd -f -R -d "${LOCAL}" "${REMOTE}" \
+    -c ":let g:miniBufExplBuffersNeeded=100" \
+    -c ":set equalalways noro" \
+    -c ":tabe $BASE" \
+    -c ":vert diffs $LOCAL" \
+    -c ":tabe $BASE" \
+    -c ":vert diffs $REMOTE" \
+    -c ":winc t"  \
+    -c ":tabe $MERGED" \
+    -c ":tabfir"
 
 EC=$?
 
 # Overwrite $MERGED only if vimdiff exits cleanly.
+# TODO:  Add a check to protect against overwriting MERGED with merge symbols in it.
 if [[ $EC == "0" ]] ; then
-    cat "${LCONFL}" > "${MERGED}"
+    cat "${LOCAL}" > "${MERGED}"
 fi
 
 exit $EC


### PR DESCRIPTION
I cleaned up and simplified diifconflicts to handle diff3 conflictstyle.  I also removed all 3-way diffs since vim displays those so poorly.  I replaced the 3-way diff with 2 more tab pages one to display the 2-way diff of LOCAL to BASE and the other to display the 2-way diff of REMOTE to BASE.  The script also now works no matter which conflictstyle is set in git config.