### PR TITLE
fix diffconflicts with CRLF EOL files

### DIFF
--- a/bin/diffconflicts
+++ b/bin/diffconflicts
@@ -90,8 +90,8 @@ RCONFL="${MERGED}.LOCAL.$$.tmp"
 trap 'rm -f "'"${LCONFL}"'" "'"${RCONFL}"'"' SIGINT SIGTERM EXIT
 
 # Remove the conflict markers for each 'side' and put each into a temp file
-sed -e '/^<<<<<<< /,/^=======$/d' -e '/^>>>>>>> /d' "${MERGED}" > "${LCONFL}"
-sed -e '/^=======$/,/^>>>>>>> /d' -e '/^<<<<<<< /d' "${MERGED}" > "${RCONFL}"
+sed -r -e '/^<<<<<<< /,/^=======\r?$/d' -e '/^>>>>>>> /d' "${MERGED}" > "${LCONFL}"
+sed -r -e '/^=======\r?$/,/^>>>>>>> /d' -e '/^<<<<<<< /d' "${MERGED}" > "${RCONFL}"
 
 # Fire up vimdiff
 $cmd -f -R -d "${LCONFL}" "${RCONFL}" \


### PR DESCRIPTION
diffconflicts does not work with CRLF end of line
![2014-10-15-223218_1913x243_scrot](https://cloud.githubusercontent.com/assets/8235752/4653043/6cd3f95e-54aa-11e4-9e1d-4a6f24b661c1.png)
