### PR TITLE
Syntax highlighting in 2-way diff

### DIFF
--- a/bin/diffconflicts
+++ b/bin/diffconflicts
@@ -82,16 +82,22 @@ printf -v QLOCAL '%q' "${LOCAL}"
 printf -v QREMOTE '%q' "${REMOTE}"
 printf -v QMERGED '%q' "${MERGED}"
 
-# Temporary files for left and right side
-LCONFL="${MERGED}.REMOTE.$$.tmp"
-RCONFL="${MERGED}.LOCAL.$$.tmp"
+# Use gnu sed if on OSX for better portability (brew install gnu-sed)
+GNU_SED="gsed"
+type $GNU_SED >/dev/null 2>&1 || GNU_SED="sed"
+
+# Temporary files for left and right side, keeping file extensions for syntax highlighting
+MERGED_PATH="$(dirname ${MERGED})"
+MERGED_FILE="$(basename ${MERGED})"
+LCONFL="${MERGED_PATH}/.REMOTE.$$.${MERGED_FILE}"
+RCONFL="${MERGED_PATH}/.LOCAL.$$.${MERGED_FILE}"
 
 # Always delete our temp files; Git will handle it's own temp files
 trap 'rm -f "'"${LCONFL}"'" "'"${RCONFL}"'"' SIGINT SIGTERM EXIT
 
 # Remove the conflict markers for each 'side' and put each into a temp file
-sed -r -e '/^<<<<<<< /,/^=======\r?$/d' -e '/^>>>>>>> /d' "${MERGED}" > "${LCONFL}"
-sed -r -e '/^=======\r?$/,/^>>>>>>> /d' -e '/^<<<<<<< /d' "${MERGED}" > "${RCONFL}"
+$GNU_SED -r -e '/^<<<<<<< /,/^=======\r?$/d' -e '/^>>>>>>> /d' "${MERGED}" > "${LCONFL}"
+$GNU_SED -r -e '/^=======\r?$/,/^>>>>>>> /d' -e '/^<<<<<<< /d' "${MERGED}" > "${RCONFL}"
 
 # Fire up vimdiff
 $cmd -f -R -d "${LCONFL}" "${RCONFL}" \


### PR DESCRIPTION
OSX portability : use gnu sed instead of sed